### PR TITLE
docs: update README with badges, description, installation, usage, and contributing

### DIFF
--- a/PS.Log.psd1
+++ b/PS.Log.psd1
@@ -9,7 +9,7 @@
     RootModule        = 'PS.Log.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.3.0'
+    ModuleVersion     = '0.4.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core', 'Desktop')

--- a/README.md
+++ b/README.md
@@ -1,3 +1,69 @@
 # PS.Log
 
-PowerShell module for trace logging
+![validate](https://github.com/johnsarie27/PS.Log/actions/workflows/validate.yml/badge.svg)
+![PSScriptAnalyzer](https://github.com/johnsarie27/PS.Log/actions/workflows/powershell.yml/badge.svg)
+![License](https://img.shields.io/github/license/johnsarie27/PS.Log)
+![PowerShell](https://img.shields.io/badge/PowerShell-5.1%2B%20%7C%20Core-blue)
+
+PS.Log is a lightweight PowerShell module for structured trace logging. It provides a consistent set of log levels — `Info`, `Warn`, `Error`, and `Debug` — with no external dependencies, making it suitable for use inside secure or air-gapped environments. Compatible with Windows PowerShell 5.1 and PowerShell Core.
+
+## Installation
+
+PS.Log is not published to the PowerShell Gallery. Install it by cloning the repository:
+
+```powershell
+git clone https://github.com/johnsarie27/PS.Log.git
+Import-Module ./PS.Log/PS.Log.psd1
+```
+
+To make the module available in all sessions, copy the module folder to a path in `$env:PSModulePath`:
+
+```powershell
+Copy-Item -Path ./PS.Log -Destination "$HOME\Documents\PowerShell\Modules\PS.Log" -Recurse
+```
+
+## Usage
+
+`Start-Log` creates the log file and returns its full path. Pass that path to every subsequent call.
+
+```powershell
+Import-Module PS.Log
+
+$logPath = Start-Log -Directory "C:\Logs" -Name "app"
+Write-LogInfo  -Path $logPath -Message "Application started"
+Write-LogWarn  -Path $logPath -Message "Low disk space detected"
+Write-LogError -Path $logPath -Message "Connection failed"
+Write-LogDebug -Path $logPath -Message "Retrying in 5 seconds"
+Stop-Log -Path $logPath
+```
+
+## Available Commands
+
+| Command | Description |
+|---|---|
+| [`Start-Log`](Documentation/Start-Log.md) | Initializes a new log session and returns the log file path |
+| [`Stop-Log`](Documentation/Stop-Log.md) | Closes the active log session |
+| [`Write-LogInfo`](Documentation/Write-LogInfo.md) | Writes an informational entry |
+| [`Write-LogWarn`](Documentation/Write-LogWarn.md) | Writes a warning entry |
+| [`Write-LogError`](Documentation/Write-LogError.md) | Writes an error entry |
+| [`Write-LogDebug`](Documentation/Write-LogDebug.md) | Writes a debug entry |
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for full details. Key points:
+
+- For minor fixes (typos, docs), open a PR directly.
+- For new functions or significant changes, open an issue first to discuss the proposal.
+- Keep each PR focused on a single function or change to simplify review.
+- Before submitting, ensure your changes pass all checks:
+
+  ```powershell
+  ./Build/build.ps1 -ResolveDependency -TaskList Test     # Pester tests
+  ./Build/build.ps1 -ResolveDependency -TaskList Analyze  # PSScriptAnalyzer
+  ```
+
+- The repo includes a dev container for VS Code. Open the workspace in a devcontainer for a fully configured environment.
+
+## License
+
+This project is licensed under the terms of the [LICENSE](LICENSE) file.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Resolves #20

- Adds CI (validate) and PSScriptAnalyzer workflow status badges
- Adds license and PowerShell version compatibility badges
- Replaces the two-line description with a proper overview paragraph
- Adds **Installation** section covering manual clone + import (no PS Gallery)
- Adds **Usage** section with a correct end-to-end example using all required parameters (`Start-Log -Directory / -Name`, captured `$logPath` passed to all subsequent calls)
- Adds **Available Commands** table with links to `/Documentation`
- Adds **Contributing** section summarizing `CONTRIBUTING.md` with build/test commands
- Adds **License** section

## Test plan

- [ ] Badges render correctly on the GitHub repo page
- [ ] All links in the commands table resolve to the correct docs pages
- [ ] `CONTRIBUTING.md` and `LICENSE` links resolve correctly
- [ ] Usage example matches the actual public API (parameters verified against source)

https://claude.ai/code/session_0136x9hWHooUvWwtdnynzY5z
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0136x9hWHooUvWwtdnynzY5z)_