### PR TITLE
Update psake build dependency from 4.9.0 to 5.0.4

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    env:
+      PSAKE_OUTPUT_FORMAT: GitHubActions
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/Build/depend.psd1
+++ b/Build/depend.psd1
@@ -17,7 +17,7 @@
     # Common modules
     BuildHelpers     = '2.0.16'
     Pester           = '5.7.1'
-    psake            = '4.9.0'
+    psake            = '5.0.4'
     #PSDeploy         = '1.0.5'
     PSScriptAnalyzer = '1.25.0'
 }


### PR DESCRIPTION
## Summary

- Bumps the `psake` build dependency from `4.9.0` to `5.0.4` in `Build/depend.psd1`

## Migration evaluation

The v5 breaking changes were assessed against this repo's build scripts — no additional changes were required:

| v5 Breaking Change | Impact |
|---|---|
| Build file must be named `psakefile.ps1` | None — `build.ps1` passes `-buildFile` explicitly |
| Legacy `psake.ps1`/`psake.cmd` runners removed | None — already using `Invoke-psake` via module |
| `$framework` global variable removed | None — not used |
| `OutputHandler`/`ColoredOutput` config removed | None — not configured |
| `$psake.build_success` | Retained for backward compatibility in v5 |
| Legacy `-depends` task syntax | Still works in v5 |

## Test plan

- [ ] `validate.yml` CI passes (`Init`, `CombineFunctionsAndStage`, `Analyze`, `Test` tasks)
- [ ] psake 5.0.4 installs cleanly via PSDepend / PSGallery

Closes #27

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4SrW42FwHmi8uNRZNyckF)_