### PR TITLE
ci: surface Pester results inline via dorny/test-reporter

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,9 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     env:
       PSAKE_OUTPUT_FORMAT: GitHubActions
     steps:
@@ -41,3 +44,12 @@ jobs:
           name: Pester Results
           path: "Artifacts/**/Test-*.xml"
           if-no-files-found: error
+
+      - name: Publish Pester results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: always()
+        with:
+          name: Pester Tests
+          path: Artifacts/**/Test-*.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -151,7 +151,7 @@ Task 'Test' -depends 'ImportStagingModule' {
 
     # create a new configuration with our settings
     $PesterConfig = New-PesterConfiguration
-    $PesterConfig.TestResult.OutputFormat = 'NUnitXML'
+    $PesterConfig.TestResult.OutputFormat = 'JUnitXml'
     $PesterConfig.TestResult.OutputPath = $TestFilePath
     $PesterConfig.TestResult.Enabled = $true
     $PesterConfig.Run.PassThru = $true


### PR DESCRIPTION
## Summary

- Adds `dorny/test-reporter` (SHA-pinned to v3.0.0) to `validate.yml` so Pester failures surface as inline Check Run annotations on PRs rather than requiring artifact downloads
- Switches Pester output format from `NUnitXML` to `JUnitXml` — NUnit v2.5 causes parsing errors in the reporter (same finding as johnsarie27/PS.SSL#47)
- Adds minimal `permissions` block (`contents: read`, `checks: write`) to the validate job; `pull-requests: write` intentionally excluded per the security review on the linked issue
- `release.yml` not modified — it runs only on tag pushes to `main`, not on PRs, so inline annotations are not applicable

Closes #29

## Test plan

- [ ] Open a draft PR and deliberately break a Pester test — confirm inline annotation appears in the `Pester Tests` Check Run
- [ ] Confirm artifact upload still works (raw XML still available under `Pester Results`)
- [ ] Confirm a passing run does not produce a failing Check Run (`fail-on-error: false`)