### PR TITLE
Fix chained comment on actions/upload-artifact pin in validate.yml

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,8 @@ jobs:
       - shell: pwsh # pester
         run: .\Build\build.ps1 -TaskList 'Test'
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 # publish pester results
+      # publish pester results
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Pester Results
           path: "Artifacts/**/Test-*.xml"


### PR DESCRIPTION
## Summary
- `validate.yml` pinned `actions/upload-artifact` with a chained comment (`# v7.0.1 # publish pester results`) on the same line as the version annotation.
- This matches a bug found in #31, where Dependabot left the version comment stale at `v3.0.0` after bumping the SHA to `v3.0.1` — likely because its parser only expects a single trailing `# vX.Y.Z` comment.
- Moves the descriptive comment to its own line so the version annotation stays unambiguous for future automated bumps.

## Test plan
- [ ] CI passes on this PR (no functional change, comment-only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCvfemHRHy7zZXRLw9TVTF)_